### PR TITLE
fix: temporarily fix inline TeX rendering issue #7

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -51,25 +51,11 @@ export class ObsidianSpreadsheet extends Plugin
 			{
 				if (!tableEl) return;
 				if (tableEl?.id === 'obsidian-sheets-parsed') return;
-
-				tableEl.querySelectorAll(':scope td').forEach(({ childNodes }) => childNodes.forEach(node => 
-				{
-					if (node.nodeType == 3) // Text node type
-						node.textContent = node.textContent?.replace(/[*_`[\]$()]|[~=]{2}/g, '\\$&') || '';
-						// See https://help.obsidian.md/Editing+and+formatting/Basic+formatting+syntax#Styling+text
-				}));
-				tableEl.querySelectorAll(':scope a.internal-link').forEach((link: HTMLAnchorElement) => 
-				{ 
-					const parsedLink = document.createElement('span');
-					parsedLink.innerText = `[[${link.getAttr('href')}|${link.innerText}]]`;
-					link.replaceWith(parsedLink);
-				});
-				tableEl.querySelectorAll(':scope span.math').forEach((link: HTMLSpanElement) =>
-					link.textContent?.trim().length ? link.textContent = `$${link.textContent || ''}$` : null
-				);
 	
-				const source = htmlToMarkdown(tableEl);
-				if (!source) return;
+				const sec = ctx.getSectionInfo(tableEl);
+				if (!sec) return;
+				const {text, lineStart, lineEnd} = sec;
+				const source = text.split(`\n`).slice(lineStart, 1 + lineEnd).join(`\n`);
 							
 				tableEl.empty();
 				ctx.addChild(new SheetElement(tableEl, source.trim().replace(/\\\\/g, '$&$&'), ctx, this.app, this));


### PR DESCRIPTION
fix #7

## Changes

- Remove unnecessary escape logic
- Manually access the raw markdown content to retrieve unrendered TeX

Although it works as expected, it blinks too frequently, and I'm not sure why this is happening.

This is a temporary workaround. I believe there's a better approach to address the issue.