### PR TITLE
fix: add frontmatter option for disabling the plugin for specific pages

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,7 @@ export class ObsidianSpreadsheet extends Plugin
 		this.registerMarkdownPostProcessor(async (el, ctx) => 
 		{
 			if (!this.settings.nativeProcessing) return;
+			if (ctx.frontmatter['disable-sheet'] === true) return;
 
 			const tableEls = el.querySelectorAll('table');
 			for (const tableEl of Array.from(tableEls))


### PR DESCRIPTION
see #19 

## Changes

 * skip processing if frontmatter has `disabled-sheet` and its value is exactly a `true`.
  (ignore other 'truthy' values.)

## Result

![image](https://github.com/NicoNekoru/obsidan-advanced-table-xt/assets/72962900/980feb57-5575-4555-b42b-2bf6b2696a4f)

## Notes

The name `disabled-sheet` is somewhat arbitrary. I think it could be replaced with a more readable name.

It would be great if one could disable the plugin on a per-table basis later.