### PR TITLE
fix: table rendering issue inside callout

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -92,8 +92,8 @@ export class ObsidianSpreadsheet extends Plugin
 				else
 				{
 					const {text, lineStart, lineEnd} = sec;
-					const textContent = text.split('\n').slice(lineStart, 1 + lineEnd);
-					textContent[0] = textContent[0].replace(/^[^|]*?(?=\|)/, '');
+					let textContent = text.split('\n').slice(lineStart, 1 + lineEnd);
+					textContent = textContent.map(line => line.replace(/^[^|]*?(?=\|)/, ''));
 					source = textContent.join('\n');
 				}
 							


### PR DESCRIPTION
Fix #22.

## Changes
 * repeat leading `>` elimination (425e890) for each line as a temporary workaround

## Result

![image](https://github.com/NicoNekoru/obsidan-advanced-table-xt/assets/72962900/b0496c8e-c658-4cd8-8783-e5ffd9e7f3df)
